### PR TITLE
WLV: adding ganache cli flag to provision enough accounts for token deploy script

### DIFF
--- a/projects/wormhole-local-validator/evm.bash
+++ b/projects/wormhole-local-validator/evm.bash
@@ -4,11 +4,11 @@ set -euo pipefail
 
 # Start EVM Chain 0
 npx pm2 delete evm0 2> /dev/null || true
-npx pm2 start 'npx ganache --chain.chainId 1 -p 8545 -m "myth like bonus scare over problem client lizard pioneer submit female collect" --block-time 1' --name evm0
+npx pm2 start 'npx ganache --wallet.totalAccounts=11 --chain.chainId 1 -p 8545 -m "myth like bonus scare over problem client lizard pioneer submit female collect" --block-time 1' --name evm0
 
 # Start EVM Chain 1
 npx pm2 delete evm1 2> /dev/null || true
-npx pm2 start 'npx ganache --chain.chainId 1397 -p 8546 -m "myth like bonus scare over problem client lizard pioneer submit female collect" --block-time 1' --name evm1
+npx pm2 start 'npx ganache --wallet.totalAccounts=11 --chain.chainId 1397 -p 8546 -m "myth like bonus scare over problem client lizard pioneer submit female collect" --block-time 1' --name evm1
 
 cd wormhole/ethereum
 


### PR DESCRIPTION
The current `deploy_test_token.js` script assumes there are at least 11 accounts on the local node.

This change makes it true for wormhole local validator